### PR TITLE
Add getEnvironment prop

### DIFF
--- a/src/RelayComponentRenderer.js
+++ b/src/RelayComponentRenderer.js
@@ -4,11 +4,11 @@ import {
   TouchableHighlight,
 } from 'react-native';
 
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 
 import Relay from 'react-relay';
 
-class RelayComponentRenderer extends Component {
+class RelayComponentRenderer extends React.Component {
   static propTypes = {
     component: PropTypes.func.isRequired,
     renderLoading: PropTypes.func,
@@ -42,7 +42,7 @@ class RelayComponentRenderer extends Component {
     delete params.environment;
 
     const {
-      component,
+      Component,
       navigationState,
       environment,
       getEnvironment,
@@ -51,7 +51,7 @@ class RelayComponentRenderer extends Component {
     } = this.props;
 
     return (<Relay.Renderer
-      Container={component}
+      Container={Component}
       queryConfig={{
         queries: navigationState.queries,
         params,
@@ -65,7 +65,7 @@ class RelayComponentRenderer extends Component {
 
         if (props) {
           // render component itself
-          return <component {...this.props} {...props} />;
+          return <Component {...this.props} {...props} />;
         }
 
         // render loading
@@ -84,5 +84,5 @@ export default (moduleProps) => (Component) =>
       <RelayComponentRenderer
         {...moduleProps}
         {...props}
-        component={Component}
+        Component={Component}
       />;

--- a/src/RelayComponentRenderer.js
+++ b/src/RelayComponentRenderer.js
@@ -10,10 +10,12 @@ import Relay from 'react-relay';
 
 class RelayComponentRenderer extends Component {
   static propTypes = {
-    component: PropTypes.func,
+    component: PropTypes.func.isRequired,
     renderLoading: PropTypes.func,
     renderError: PropTypes.func,
-    navigationState: PropTypes.object,
+    navigationState: PropTypes.object.isRequired,
+    environment: PropTypes.object,
+    getEnvironment: PropTypes.func,
   };
 
   renderLoading() {
@@ -39,26 +41,35 @@ class RelayComponentRenderer extends Component {
 
     delete params.environment;
 
+    const {
+      component,
+      navigationState,
+      environment,
+      getEnvironment,
+      renderError,
+      renderLoading,
+    } = this.props;
+
     return (<Relay.Renderer
-      Container={this.props.component}
+      Container={component}
       queryConfig={{
-        queries: this.props.navigationState.queries,
+        queries: navigationState.queries,
         params,
-        name: `rnrf_relay_renderer_${this.props.navigationState.key}_route`, // construct route name based on navState key
+        name: `rnrf_relay_renderer_${navigationState.key}_route`, // construct route name based on navState key
       }}
-      environment={this.props.navigationState.environment || this.props.environment || Relay.Store}
+      environment={navigationState.environment || environment || (getEnvironment && getEnvironment()) || Relay.Store}
       render={({done, error, props, retry, stale}) => {
         if (error) {
-          return (this.props.renderError || this.renderError)(error, retry);
+          return (renderError || this.renderError)(error, retry);
         }
 
         if (props) {
           // render component itself
-          return <this.props.component {...this.props} {...props} />;
+          return <component {...this.props} {...props} />;
         }
 
         // render loading
-        return (this.props.renderLoading || this.renderLoading)(this.props.navigationState)
+        return (renderLoading || this.renderLoading)(navigationState)
       }}
     />);
   }


### PR DESCRIPTION
This enables setting the Relay environment dynamically, e.g. a new environment per session, without needing to re-render the RNRF router.
